### PR TITLE
Attempt to remedy readthedocs empty module

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,15 @@
+version: 2
+
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.11"
+
+# Build from the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Explicitly set the version of Python and its requirements
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,6 +4,7 @@ include LICENSE
 include *.md
 
 include .bumpversion.cfg
+include .readthedocs.yml
 include pyproject.toml
 include Makefile
 
@@ -12,6 +13,7 @@ recursive-include docs *.gif
 recursive-include docs *.md
 recursive-include docs *.py
 recursive-include docs *.rst
+recursive-include docs *.txt
 recursive-include docs Makefile
 
 prune .github
@@ -25,3 +27,6 @@ global-exclude *.pyo
 global-exclude .git
 global-exclude .ipynb_checkpoints
 global-exclude .DS_Store
+
+
+  recursive-include docs *.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,4 @@
+sphinx==5.3.0
+sphinx_rtd_theme==1.1.1
+readthedocs-sphinx-search==0.1.1
+easierscrape


### PR DESCRIPTION
The readthedocs build works fine locally, but doesn't import easierscrape when built online. This attempts to resolve that